### PR TITLE
change docker in multi-stage mode to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG IMAGE=store/intersystems/iris-community:2020.1.0.204.0
 ARG IMAGE=intersystemsdc/iris-community:2020.1.0.209.0-zpm
 ARG IMAGE=intersystemsdc/iris-community:2020.2.0.204.0-zpm
 ARG IMAGE=intersystemsdc/iris-community
-FROM $IMAGE
+FROM $IMAGE as builder
 
 USER root
 
@@ -42,3 +42,11 @@ RUN \
 
 # bringing the standard shell back
 SHELL ["/bin/bash", "-c"]
+
+FROM $IMAGE as final
+
+ADD --chown=${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} https://github.com/grongierisc/iris-docker-multi-stage-script/releases/latest/download/copy-data.py /irisdev/app/copy-data.py
+
+RUN --mount=type=bind,source=/,target=/builder/root,from=builder \
+    cp -f /builder/root/usr/irissys/iris.cpf /usr/irissys/iris.cpf && \
+    python3 /irisdev/app/copy-data.py -c /usr/irissys/iris.cpf -d /builder/root/ 


### PR DESCRIPTION
before
restforms2-angularui-demo-iris-1   791MB (virtual 3.67GB)
after
restforms2-angularui-demo-iris-1   791MB (virtual 3.05GB)
change docker in multi-stage mode to reduce size